### PR TITLE
fixes around utf-8 unquoting

### DIFF
--- a/okjson.rb
+++ b/okjson.rb
@@ -263,13 +263,13 @@ module OkJson
   # Unquote will raise an error if q contains control characters.
   def unquote(q)
     q = q[1...-1]
-    a = q.dup # allocate a big enough string
     rubydoesenc = false
     # In ruby >= 1.9, a[w] is a codepoint, not a byte.
-    if a.class.method_defined?(:force_encoding)
-      a.force_encoding('UTF-8')
+    if q.class.method_defined?(:force_encoding)
+      q.force_encoding('UTF-8')
       rubydoesenc = true
     end
+    a = q.dup # allocate a big enough string
     r, w = 0, 0
     while r < q.length
       c = q[r]


### PR DESCRIPTION
Was running into parse failures in heroku/heroku from config vars that included non latin characters.  \xC3 in particular seems problematic.  I had trouble getting tests to work around this though, could definitely use some help on that.
