### PR TITLE
JSON text and values are empty if their length is <= 0

### DIFF
--- a/okjson.rb
+++ b/okjson.rb
@@ -55,7 +55,7 @@ module OkJson
   # Note: this is almost the same as valparse,
   # except that it does not accept atomic values.
   def textparse(ts)
-    if ts.length < 0
+    if ts.length <= 0
       raise Error, 'empty'
     end
 
@@ -72,7 +72,7 @@ module OkJson
   # Parses a "value" in the sense of RFC 4627.
   # Returns the parsed value and any trailing tokens.
   def valparse(ts)
-    if ts.length < 0
+    if ts.length <= 0
       raise Error, 'empty'
     end
 


### PR DESCRIPTION
If I’m reading the code correctly, it should raise empty when the `length <= 0`.
