### PR TITLE
Make all methods private except decode and encode

### DIFF
--- a/okjson.rb
+++ b/okjson.rb
@@ -50,6 +50,28 @@ module OkJson
   end
 
 
+  # Encodes x into a json text. It may contain only
+  # Array, Hash, String, Numeric, true, false, nil.
+  # (Note, this list excludes Symbol.)
+  # X itself must be an Array or a Hash.
+  # No other value can be encoded, and an error will
+  # be raised if x contains any other value, such as
+  # Nan, Infinity, Symbol, and Proc, or if a Hash key
+  # is not a String.
+  # Strings contained in x must be valid UTF-8.
+  def encode(x)
+    case x
+    when Hash    then objenc(x)
+    when Array   then arrenc(x)
+    else
+      raise Error, 'root value must be an Array or a Hash'
+    end
+  end
+
+
+private
+
+
   # Parses a "json text" in the sense of RFC 4627.
   # Returns the parsed value and any trailing tokens.
   # Note: this is almost the same as valparse,
@@ -389,25 +411,6 @@ module OkJson
     when ?A <= c && c <= ?Z then c.ord - ?A.ord + 10
     else
       raise Error, "invalid hex code #{c}"
-    end
-  end
-
-
-  # Encodes x into a json text. It may contain only
-  # Array, Hash, String, Numeric, true, false, nil.
-  # (Note, this list excludes Symbol.)
-  # X itself must be an Array or a Hash.
-  # No other value can be encoded, and an error will
-  # be raised if x contains any other value, such as
-  # Nan, Infinity, Symbol, and Proc, or if a Hash key
-  # is not a String.
-  # Strings contained in x must be valid UTF-8.
-  def encode(x)
-    case x
-    when Hash    then objenc(x)
-    when Array   then arrenc(x)
-    else
-      raise Error, 'root value must be an Array or a Hash'
     end
   end
 


### PR DESCRIPTION
In Ruby, private is more of a suggestion than a policy, but we shouldn’t encourage calling methods other than `decode` and `encode`. This will allow us to refactor private methods without worrying about breaking public APIs.
