### PR TITLE
Fix Integer syntax not supported by 1.8.7

### DIFF
--- a/okjson.rb
+++ b/okjson.rb
@@ -268,7 +268,7 @@ private
       elsif m[2]
         [:val, m[0], Float(m[0])]
       else
-        [:val, m[0], Integer(m[1])*(10**Integer(m[3][1..-1], 10))]
+        [:val, m[0], Integer(m[1])*(10**m[3][1..-1].to_i(10))]
       end
     else
       []


### PR DESCRIPTION
Didn't test the previous fix on 1.8.7 before PRing, I'm not sure if you're intending to support it or not. Ignore if you aren't!
